### PR TITLE
Minor code change for 2 problems I rand into when integrating

### DIFF
--- a/custom_components/crestron/__init__.py
+++ b/custom_components/crestron/__init__.py
@@ -214,14 +214,14 @@ class CrestronHub:
                     self.hub.set_digital(int(join[1:]), value)
             # Analog Join
             if join[:1] == "a":
-                if result != "None":
+                if result != "None" and result is not None:
                     _LOGGER.debug(
                         f"sync_joins_to_hub setting analog join {int(join[1:])} to {int(result)}"
                     )
                     self.hub.set_analog(int(join[1:]), int(result))
             # Serial Join
             if join[:1] == "s":
-                if result != "None":
+                if result != "None" and result is not None:
                     _LOGGER.debug(
                         f"sync_joins_to_hub setting serial join {int(join[1:])} to {str(result)}"
                     )

--- a/custom_components/crestron/__init__.py
+++ b/custom_components/crestron/__init__.py
@@ -174,9 +174,9 @@ class CrestronHub:
                         # Digital Join
                         if join[:1] == "d":
                             value = None
-                            if update_result == STATE_ON or update_result == "True":
+                            if update_result == STATE_ON or update_result == "True" or update_result is True:
                                 value = True
-                            elif update_result == STATE_OFF or update_result == "False":
+                            elif update_result == STATE_OFF or update_result == "False" or update_result is False:
                                 value = False
                             if value is not None:
                                 _LOGGER.debug(
@@ -203,9 +203,9 @@ class CrestronHub:
             # Digital Join
             if join[:1] == "d":
                 value = None
-                if result == STATE_ON or result == "True":
+                if result == STATE_ON or result == "True" or result is True:
                     value = True
-                elif result == STATE_OFF or result == "False":
+                elif result == STATE_OFF or result == "False" or result is False:
                     value = False
                 if value is not None:
                     _LOGGER.debug(

--- a/custom_components/crestron/media_player.py
+++ b/custom_components/crestron/media_player.py
@@ -99,7 +99,7 @@ class CrestronRoom(MediaPlayerEntity):
     @property
     def source(self):
         source_num = self._hub.get_analog(self._source_number_join)
-        if source_num == 0:
+        if source_num == 0 or source_num not in self._sources:
             return None
         else:
             return self._sources[source_num]


### PR DESCRIPTION
1. Fixes a problem when a value_template in a digital to_joins was resulting in update_result being an actual boolean value and consequently it was never getting sent to the Crestron system: `value_template: "{{is_state('lock.my_lock', 'locked')}}"`
2. Fixes a problem during startup where result was a None value and consequently an error was showing up in the logs when trying to turn it into an int.